### PR TITLE
Fix parser

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -455,7 +455,7 @@ export function parseText(source) {
       else result.push({ ...p });
     }
   });
-  result = result.map(p => p.type == 'text' ? '`' + Q(p.value) + '`' : '(' + p.value + ')').join('+');
+  result = '`' + result.map(p => p.type == 'text' ? Q(p.value) : '${' + p.value + '}').join('') + '`';
   return { result, parts, staticText };
 }
 


### PR DESCRIPTION
This PR fixes the bug when two expression would be added instead of concatenating.

### Bug
```html
<div>{1}{2}</div>     <!-- 3, should be 12 -->
<div> {1}{2}</div>    <!-- works fine -->
<div> {(1}{2)}</div>  <!-- again 3, should be error -->
```

https://malinajs.github.io/repl/#/share/HigJLc4mZOH